### PR TITLE
Fix time-based filters to eliminate zero values

### DIFF
--- a/scheduling-api-graphql/scheduling-api-graphql-beans/scheduling-api-graphql-beans-input/src/main/java/org/ow2/proactive/scheduling/api/graphql/beans/input/JobInput.java
+++ b/scheduling-api-graphql/scheduling-api-graphql-beans/scheduling-api-graphql-beans-input/src/main/java/org/ow2/proactive/scheduling/api/graphql/beans/input/JobInput.java
@@ -293,10 +293,6 @@ public class JobInput extends AbstractApiType {
                 sb.append(Constants.QUOTE);
             }
 
-            comparableLongString(InputFields.LAST_UPDATED_TIME.getName(),
-                                 this.beforeLastUpdatedTime,
-                                 this.afterLastUpdatedTime);
-
             if (!Strings.isNullOrEmpty(this.owner)) {
                 sb.append(' ');
                 sb.append(InputFields.OWNER.getName());
@@ -334,6 +330,10 @@ public class JobInput extends AbstractApiType {
             comparableLongString(InputFields.SUBMITTED_TIME.getName(),
                                  this.beforeSubmittedTime,
                                  this.afterSubmittedTime);
+
+            comparableLongString(InputFields.LAST_UPDATED_TIME.getName(),
+                                 this.beforeLastUpdatedTime,
+                                 this.afterLastUpdatedTime);
 
             comparableLongString(InputFields.START_TIME.getName(), this.beforeStartTime, this.afterStartTime);
 

--- a/scheduling-api-graphql/scheduling-api-graphql-fetchers/src/main/java/org/ow2/proactive/scheduling/api/graphql/fetchers/converter/JobInputConverter.java
+++ b/scheduling-api-graphql/scheduling-api-graphql-fetchers/src/main/java/org/ow2/proactive/scheduling/api/graphql/fetchers/converter/JobInputConverter.java
@@ -116,7 +116,7 @@ public class JobInputConverter extends AbstractJobTaskInputConverter<JobData, Jo
             if (jobId != -1L) {
                 predicates.add(criteriaBuilder.equal(root.get("id"), jobId));
             }
-            comparableLongPredicated(i.getComparableId(), "id", root, criteriaBuilder, predicates);
+            comparableLongPredicated(i.getComparableId(), "id", root, criteriaBuilder, predicates, false);
 
             // Job name based predicate
             if (!Strings.isNullOrEmpty(jobName)) {
@@ -126,9 +126,6 @@ public class JobInputConverter extends AbstractJobTaskInputConverter<JobData, Jo
                                                                                  jobName);
                 predicates.add(jobNamePredicate);
             }
-
-            // Job last updated time based predicate
-            comparableLongPredicated(i.getLastUpdatedTime(), "lastUpdatedTime", root, criteriaBuilder, predicates);
 
             // Job owner based predicate
             if (!Strings.isNullOrEmpty(owner)) {
@@ -160,13 +157,21 @@ public class JobInputConverter extends AbstractJobTaskInputConverter<JobData, Jo
             }
 
             // Job submitted time based predicate
-            comparableLongPredicated(i.getSubmittedTime(), "submittedTime", root, criteriaBuilder, predicates);
+            comparableLongPredicated(i.getSubmittedTime(), "submittedTime", root, criteriaBuilder, predicates, true);
+
+            // Job last updated time based predicate
+            comparableLongPredicated(i.getLastUpdatedTime(),
+                                     "lastUpdatedTime",
+                                     root,
+                                     criteriaBuilder,
+                                     predicates,
+                                     true);
 
             // Job start time based predicate
-            comparableLongPredicated(i.getStartedTime(), "startTime", root, criteriaBuilder, predicates);
+            comparableLongPredicated(i.getStartedTime(), "startTime", root, criteriaBuilder, predicates, true);
 
             // Job start time based predicate
-            comparableLongPredicated(i.getFinishedTime(), "finishedTime", root, criteriaBuilder, predicates);
+            comparableLongPredicated(i.getFinishedTime(), "finishedTime", root, criteriaBuilder, predicates, true);
 
             // Number of pending/running/etc task predicate
             comparableIntegerPredicated(i.getNumberOfPendingTasks(),
@@ -242,7 +247,7 @@ public class JobInputConverter extends AbstractJobTaskInputConverter<JobData, Jo
     }
 
     private void comparableLongPredicated(ComparableLongInput input, String name, Root<JobData> root,
-            CriteriaBuilder criteriaBuilder, List<Predicate> predicates) {
+            CriteriaBuilder criteriaBuilder, List<Predicate> predicates, boolean filterZeroLess) {
         long before = -1;
         long after = -1;
         if (input != null) {
@@ -251,6 +256,9 @@ public class JobInputConverter extends AbstractJobTaskInputConverter<JobData, Jo
         }
         if (before != -1L) {
             predicates.add(criteriaBuilder.lessThanOrEqualTo(root.get(name), before));
+            if (filterZeroLess && after == -1L) {
+                predicates.add(criteriaBuilder.greaterThan(root.get(name), 0L));
+            }
         }
         if (after != -1L) {
             predicates.add(criteriaBuilder.greaterThanOrEqualTo(root.get(name), after));

--- a/scheduling-api-http/src/integration-test/java/org/ow2/proactive/scheduling/api/GraphqlServiceIntegrationTest.java
+++ b/scheduling-api-http/src/integration-test/java/org/ow2/proactive/scheduling/api/GraphqlServiceIntegrationTest.java
@@ -630,20 +630,63 @@ public class GraphqlServiceIntegrationTest {
     @Rollback
     @Test
     @Transactional
+    public void testQueryJobsFilterBySubmittedTime() {
+        JobData job1 = createJobData("job1", "bobot", JobPriority.HIGH, "test", JobStatus.KILLED);
+        job1.setSubmittedTime(100);
+        entityManager.persist(job1);
+
+        JobData job2 = createJobData("job1", "bobot", JobPriority.HIGH, "test", JobStatus.KILLED);
+        job2.setSubmittedTime(2000);
+        entityManager.persist(job2);
+
+        JobData job3 = createJobData("job1", "bobot", JobPriority.HIGH, "test", JobStatus.KILLED);
+        entityManager.persist(job3);
+
+        Map<String, Object> queryResult = executeGraphqlQuery(String.format("{ jobs(%s:{submittedTime: {after: %s}}) " +
+                                                                            "{ edges { cursor node { id owner submittedTime} } } }",
+                                                                            FILTER.getName(),
+                                                                            1000));
+        List<?> jobNodes = (List<?>) getField(queryResult, "data", "jobs", "edges");
+        assertThat(jobNodes).hasSize(1);
+
+        queryResult = executeGraphqlQuery(String.format("{ jobs(%s:{submittedTime: {before: %s}}) " +
+                                                        "{ edges { cursor node { id owner submittedTime} } } }",
+                                                        FILTER.getName(),
+                                                        1000));
+        jobNodes = (List<?>) getField(queryResult, "data", "jobs", "edges");
+        assertThat(jobNodes).hasSize(1);
+    }
+
+    @Rollback
+    @Test
+    @Transactional
     public void testQueryJobsFilterByLastUpdatedTime() {
         JobData job1 = createJobData("job1", "bobot", JobPriority.HIGH, "test", JobStatus.KILLED);
+        job1.setSubmittedTime(100);
         job1.setLastUpdatedTime(job1.getSubmittedTime());
         entityManager.persist(job1);
 
         JobData job2 = createJobData("job1", "bobot", JobPriority.HIGH, "test", JobStatus.KILLED);
+        job2.setSubmittedTime(100);
         job2.setLastUpdatedTime(job2.getSubmittedTime() + 2000);
         entityManager.persist(job2);
+
+        JobData job3 = createJobData("job1", "bobot", JobPriority.HIGH, "test", JobStatus.KILLED);
+        job3.setSubmittedTime(100);
+        entityManager.persist(job3);
 
         Map<String, Object> queryResult = executeGraphqlQuery(String.format("{ jobs(%s:{lastUpdatedTime: {after: %s}}) " +
                                                                             "{ edges { cursor node { id owner lastUpdatedTime} } } }",
                                                                             FILTER.getName(),
                                                                             job2.getSubmittedTime() + 1000));
         List<?> jobNodes = (List<?>) getField(queryResult, "data", "jobs", "edges");
+        assertThat(jobNodes).hasSize(1);
+
+        queryResult = executeGraphqlQuery(String.format("{ jobs(%s:{lastUpdatedTime: {before: %s}}) " +
+                                                        "{ edges { cursor node { id owner lastUpdatedTime} } } }",
+                                                        FILTER.getName(),
+                                                        job2.getSubmittedTime() + 1000));
+        jobNodes = (List<?>) getField(queryResult, "data", "jobs", "edges");
         assertThat(jobNodes).hasSize(1);
     }
 
@@ -652,18 +695,31 @@ public class GraphqlServiceIntegrationTest {
     @Transactional
     public void testQueryJobsFilterByStartTime() {
         JobData job1 = createJobData("job1", "bobot", JobPriority.HIGH, "test", JobStatus.KILLED);
+        job1.setSubmittedTime(100);
         job1.setStartTime(job1.getSubmittedTime() + 10);
         entityManager.persist(job1);
 
         JobData job2 = createJobData("job1", "bobot", JobPriority.HIGH, "test", JobStatus.KILLED);
+        job2.setSubmittedTime(100);
         job2.setStartTime(job2.getSubmittedTime() + 2000);
         entityManager.persist(job2);
+
+        JobData job3 = createJobData("job1", "bobot", JobPriority.HIGH, "test", JobStatus.KILLED);
+        job3.setSubmittedTime(100);
+        entityManager.persist(job3);
 
         Map<String, Object> queryResult = executeGraphqlQuery(String.format("{ jobs(%s:{startTime: {after: %s}}) " +
                                                                             "{ edges { cursor node { id owner startTime} } } }",
                                                                             FILTER.getName(),
                                                                             job2.getSubmittedTime() + 1000));
         List<?> jobNodes = (List<?>) getField(queryResult, "data", "jobs", "edges");
+        assertThat(jobNodes).hasSize(1);
+
+        queryResult = executeGraphqlQuery(String.format("{ jobs(%s:{startTime: {before: %s}}) " +
+                                                        "{ edges { cursor node { id owner startTime} } } }",
+                                                        FILTER.getName(),
+                                                        job2.getSubmittedTime() + 1000));
+        jobNodes = (List<?>) getField(queryResult, "data", "jobs", "edges");
         assertThat(jobNodes).hasSize(1);
     }
 
@@ -672,18 +728,31 @@ public class GraphqlServiceIntegrationTest {
     @Transactional
     public void testQueryJobsFilterByFinishedTime() {
         JobData job1 = createJobData("job1", "bobot", JobPriority.HIGH, "test", JobStatus.KILLED);
+        job1.setSubmittedTime(100);
         job1.setFinishedTime(job1.getSubmittedTime() + 10);
         entityManager.persist(job1);
 
         JobData job2 = createJobData("job1", "bobot", JobPriority.HIGH, "test", JobStatus.KILLED);
+        job2.setSubmittedTime(100);
         job2.setFinishedTime(job2.getSubmittedTime() + 2000);
         entityManager.persist(job2);
+
+        JobData job3 = createJobData("job1", "bobot", JobPriority.HIGH, "test", JobStatus.KILLED);
+        job3.setSubmittedTime(100);
+        entityManager.persist(job3);
 
         Map<String, Object> queryResult = executeGraphqlQuery(String.format("{ jobs(%s:{finishedTime: {after: %s}}) " +
                                                                             "{ edges { cursor node { id owner finishedTime} } } }",
                                                                             FILTER.getName(),
                                                                             job2.getSubmittedTime() + 1000));
         List<?> jobNodes = (List<?>) getField(queryResult, "data", "jobs", "edges");
+        assertThat(jobNodes).hasSize(1);
+
+        queryResult = executeGraphqlQuery(String.format("{ jobs(%s:{finishedTime: {before: %s}}) " +
+                                                        "{ edges { cursor node { id owner finishedTime} } } }",
+                                                        FILTER.getName(),
+                                                        job2.getSubmittedTime() + 1000));
+        jobNodes = (List<?>) getField(queryResult, "data", "jobs", "edges");
         assertThat(jobNodes).hasSize(1);
     }
 


### PR DESCRIPTION
The default long values stored in the database is zero, which corresponds to a non-existing time which must be filtered out.
In consequence, add a greater than zero where clause in the generated sql queries.