### PR TITLE
Add log4j2 component file

### DIFF
--- a/scheduling-api-graphql/scheduling-api-graphql-services/build.gradle
+++ b/scheduling-api-graphql/scheduling-api-graphql-services/build.gradle
@@ -38,4 +38,9 @@ dependencies {
     compile 'org.apache.httpcomponents:httpclient'
     compile project(":scheduling-api-graphql:scheduling-api-graphql-fetchers")
     testCompile 'org.springframework.boot:spring-boot-starter-test'
+    testCompile "org.apache.logging.log4j:log4j-web:2.4.1"
+    testCompile "org.apache.logging.log4j:log4j-api:2.4.1"
+    testCompile "org.apache.logging.log4j:log4j-core:2.4.1"
+    testCompile "org.apache.logging.log4j:log4j-slf4j-impl:2.4.1"
+
 }

--- a/scheduling-api-http/build.gradle
+++ b/scheduling-api-http/build.gradle
@@ -45,8 +45,8 @@ dependencies {
     compile "org.apache.logging.log4j:log4j-web"
 
     // route all log4j 1.2 and jul to slf4j
-    compile 'org.slf4j:log4j-over-slf4j:1.7.16'
-    compile 'org.slf4j:jul-to-slf4j:1.7.16'
+    compile 'org.slf4j:log4j-over-slf4j'
+    compile 'org.slf4j:jul-to-slf4j'
 
     compile "org.projectlombok:lombok"
 

--- a/scheduling-api-http/src/main/resources/log4j2.component.properties
+++ b/scheduling-api-http/src/main/resources/log4j2.component.properties
@@ -1,0 +1,1 @@
+log4j.configurationFile=log4j2.xml


### PR DESCRIPTION
Also:
  - use specific log4j2 version due to spring version incompatibility in some tests
  - use parent-bom versioning for slf4j libs