### PR TITLE
Add EntityScanRoot annotation to prevent scanning of the whole proactive root folder

### DIFF
--- a/scheduling-api-http/src/main/java/org/ow2/proactive/scheduling/api/Application.java
+++ b/scheduling-api-http/src/main/java/org/ow2/proactive/scheduling/api/Application.java
@@ -27,6 +27,7 @@ package org.ow2.proactive.scheduling.api;
 
 import javax.sql.DataSource;
 
+import org.ow2.proactive.scheduling.api.util.EntityScanRoot;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
@@ -55,6 +56,7 @@ import com.ulisesbocchio.jasyptspringboot.annotation.EnableEncryptableProperties
 @EnableAutoConfiguration
 @EnableEncryptableProperties
 @EntityScan(basePackages = "org.ow2.proactive.scheduler.core.db")
+@EntityScanRoot("classpath*:scheduler-server*.jar")
 @PropertySources({ @PropertySource(value = "classpath:application.properties"),
                    @PropertySource(value = "file:${proactive.home}/config/scheduling-api/application.properties", ignoreResourceNotFound = true),
                    @PropertySource(value = "classpath:application-test.properties", ignoreResourceNotFound = true) })

--- a/scheduling-api-http/src/main/java/org/ow2/proactive/scheduling/api/util/EntityScanRoot.java
+++ b/scheduling-api-http/src/main/java/org/ow2/proactive/scheduling/api/util/EntityScanRoot.java
@@ -1,0 +1,55 @@
+/*
+ * ProActive Parallel Suite(TM):
+ * The Open Source library for parallel and distributed
+ * Workflows & Scheduling, Orchestration, Cloud Automation
+ * and Big Data Analysis on Enterprise Grids & Clouds.
+ *
+ * Copyright (c) 2007 - 2017 ActiveEon
+ * Contact: contact@activeeon.com
+ *
+ * This library is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation: version 3 of
+ * the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * If needed, contact us to obtain a release under GPL Version 2 or 3
+ * or a different license than the AGPL.
+ */
+package org.ow2.proactive.scheduling.api.util;
+
+import java.lang.annotation.*;
+
+import org.springframework.context.annotation.Import;
+
+
+/**
+ * Allows to override the entity scan root
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Import(EntityScanRootRegistrar.class)
+public @interface EntityScanRoot {
+
+    /**
+     * Override the default entity scan root ("classpath:") to a more accurate path.
+     * This expression is parsed by a PathMatchingResourcePatternResolver.
+     *
+     * Supports wild card notation e.g. classpath*:path/somejar*.jar. The wildcard must return a single resource
+     *
+     * @see org.springframework.core.io.support.PathMatchingResourcePatternResolver#getResource(String)
+     * @see org.springframework.core.io.support.PathMatchingResourcePatternResolver#getResources(String)
+     *
+     * @return the entity scan classpath string
+     */
+    String value() default "classpath:";
+
+}

--- a/scheduling-api-http/src/main/java/org/ow2/proactive/scheduling/api/util/EntityScanRootRegistrar.java
+++ b/scheduling-api-http/src/main/java/org/ow2/proactive/scheduling/api/util/EntityScanRootRegistrar.java
@@ -1,0 +1,171 @@
+/*
+ * ProActive Parallel Suite(TM):
+ * The Open Source library for parallel and distributed
+ * Workflows & Scheduling, Orchestration, Cloud Automation
+ * and Big Data Analysis on Enterprise Grids & Clouds.
+ *
+ * Copyright (c) 2007 - 2017 ActiveEon
+ * Contact: contact@activeeon.com
+ *
+ * This library is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation: version 3 of
+ * the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * If needed, contact us to obtain a release under GPL Version 2 or 3
+ * or a different license than the AGPL.
+ */
+package org.ow2.proactive.scheduling.api.util;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.SmartInitializingSingleton;
+import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.beans.factory.config.BeanPostProcessor;
+import org.springframework.beans.factory.config.ConstructorArgumentValues.ValueHolder;
+import org.springframework.beans.factory.support.BeanDefinitionRegistry;
+import org.springframework.beans.factory.support.GenericBeanDefinition;
+import org.springframework.context.annotation.ImportBeanDefinitionRegistrar;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.AnnotationAttributes;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
+import org.springframework.core.io.support.ResourcePatternResolver;
+import org.springframework.core.type.AnnotationMetadata;
+import org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean;
+import org.springframework.orm.jpa.persistenceunit.MutablePersistenceUnitInfo;
+import org.springframework.orm.jpa.persistenceunit.PersistenceUnitPostProcessor;
+import org.springframework.util.Assert;
+
+import lombok.extern.log4j.Log4j2;
+
+
+/**
+ * {@link ImportBeanDefinitionRegistrar} used by {@link EntityScanRoot}.
+ *
+ */
+@Log4j2
+class EntityScanRootRegistrar implements ImportBeanDefinitionRegistrar {
+
+    private static final String BEAN_NAME = "entityScanRootBeanPostProcessor";
+
+    @Override
+    public void registerBeanDefinitions(AnnotationMetadata importingClassMetadata, BeanDefinitionRegistry registry) {
+        String entityScanRoot = getEntityScanRoot(importingClassMetadata);
+        if (!registry.containsBeanDefinition(BEAN_NAME)) {
+            addEntityScanRootBeanPostProcessor(registry, entityScanRoot);
+        } else {
+            updateEntityScanRootBeanPostProcessor(registry, entityScanRoot);
+        }
+    }
+
+    private String getEntityScanRoot(AnnotationMetadata metadata) {
+        AnnotationAttributes attributes = AnnotationAttributes.fromMap(metadata.getAnnotationAttributes(EntityScanRoot.class.getName()));
+        String scanRoot = attributes.getString("value");
+        Assert.state(!scanRoot.isEmpty(), "@EntityScanRoot value attribute cannot be empty");
+        return scanRoot;
+    }
+
+    private void addEntityScanRootBeanPostProcessor(BeanDefinitionRegistry registry, String scanRoot) {
+        GenericBeanDefinition beanDefinition = new GenericBeanDefinition();
+        beanDefinition.setBeanClass(EntityScanRootBeanPostProcessor.class);
+        beanDefinition.getConstructorArgumentValues().addGenericArgumentValue(scanRoot);
+        beanDefinition.setRole(BeanDefinition.ROLE_INFRASTRUCTURE);
+        // We don't need this one to be post processed otherwise it can cause a
+        // cascade of bean instantiation that we would rather avoid.
+        beanDefinition.setSynthetic(true);
+        registry.registerBeanDefinition(BEAN_NAME, beanDefinition);
+    }
+
+    private void updateEntityScanRootBeanPostProcessor(BeanDefinitionRegistry registry, String scanRoot) {
+        BeanDefinition definition = registry.getBeanDefinition(BEAN_NAME);
+        ValueHolder constructorArguments = definition.getConstructorArgumentValues()
+                                                     .getGenericArgumentValue(String.class);
+        constructorArguments.setValue(scanRoot);
+    }
+
+    /**
+     * {@link BeanPostProcessor} to set
+     * {@link MutablePersistenceUnitInfo#setPersistenceUnitRootUrl(java.net.URL)} based
+     * on an {@link EntityScanRoot} annotation.
+     */
+    static class EntityScanRootBeanPostProcessor implements BeanPostProcessor, SmartInitializingSingleton, Ordered {
+
+        private final String entityScanRoot;
+
+        private boolean processed;
+
+        EntityScanRootBeanPostProcessor(String entityScanRoot) {
+            this.entityScanRoot = entityScanRoot;
+        }
+
+        @Override
+        public Object postProcessBeforeInitialization(Object bean, String beanName) throws BeansException {
+            if (bean instanceof LocalContainerEntityManagerFactoryBean) {
+                LocalContainerEntityManagerFactoryBean factoryBean = (LocalContainerEntityManagerFactoryBean) bean;
+                factoryBean.setPersistenceUnitPostProcessors(new PersistenceUnitPostProcessor() {
+                    @Override
+                    public void postProcessPersistenceUnitInfo(MutablePersistenceUnitInfo pui) {
+                        ResourcePatternResolver resourcePatternResolver = new PathMatchingResourcePatternResolver();
+                        try {
+                            if (entityScanRoot.startsWith("classpath*:")) {
+                                Resource[] matchingResources = resourcePatternResolver.getResources(entityScanRoot);
+                                if (matchingResources.length == 0) {
+                                    log.error("No matching resources for " + entityScanRoot + ", aborting");
+                                } else if (matchingResources.length > 1) {
+                                    log.error("Multiple matching resources for " + entityScanRoot + ": " +
+                                              Arrays.asList(matchingResources).stream().map(resource -> {
+                                                  try {
+                                                      return resource.getURL().toExternalForm();
+                                                  } catch (IOException e) {
+                                                      return "";
+                                                  }
+                                              }).collect(Collectors.joining(",")));
+                                } else {
+                                    pui.setPersistenceUnitRootUrl(matchingResources[0].getURL());
+                                }
+                            } else {
+                                pui.setPersistenceUnitRootUrl(resourcePatternResolver.getResource(entityScanRoot)
+                                                                                     .getURL());
+                            }
+                        } catch (IOException e) {
+                            log.error("Error when setting persistence unit root url for " + entityScanRoot, e);
+                        }
+                    }
+                });
+                this.processed = true;
+            }
+            return bean;
+        }
+
+        @Override
+        public Object postProcessAfterInitialization(Object bean, String beanName) throws BeansException {
+            return bean;
+        }
+
+        @Override
+        public void afterSingletonsInstantiated() {
+            Assert.state(this.processed,
+                         "Unable to configure " + "LocalContainerEntityManagerFactoryBean from @EntityScanRoot, " +
+                                         "ensure an appropriate bean is registered.");
+        }
+
+        @Override
+        public int getOrder() {
+            return 0;
+        }
+
+    }
+
+}


### PR DESCRIPTION

 - inspired from EntityScan annotation implementation
 - allows to override the default scan root 'classpath:' to restrict to specific folders or jar files